### PR TITLE
use v4 uuids for post id generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ serde_with = "3.12.0"
 cfg-if = "0.1.2"
 reqwest = { version = "0.12.15", features = ["json"] }
 stringreader = "0.1.1"
-uuid = { version = "1.17.0", features = ["v7", "serde", "js"] }
+uuid = { version = "1.17.0", features = ["v4", "serde", "js"] }
 k256 = { version = "0.13.4", default-features = false, features = ["std", "jwk"] }
 ciborium = "0.2.2"
 chrono = "0.4.40"

--- a/workers/yral-upload-video/src/server_impl/upload_video_to_canister.rs
+++ b/workers/yral-upload-video/src/server_impl/upload_video_to_canister.rs
@@ -51,7 +51,7 @@ pub async fn upload_video_to_canister_impl(
                 description: post_details.description,
                 video_uid: post_details.video_uid,
                 creator_principal: user_ic_agent.get_principal().unwrap(),
-                id: Uuid::now_v7().to_string(),
+                id: Uuid::new_v4().to_string(),
             },
         )
         .await;
@@ -162,7 +162,7 @@ async fn upload_video_to_service_canister(
         .get_user_profile_details(post_details.creator_principal)
         .await?;
 
-    let post_id = Uuid::now_v7().to_string();
+    let post_id = post_details.id;
 
     if let Result1::Ok(_user_details) = user_details {
         let post_service = UserPostService(USER_POST_SERVICE_ID, admin_ic_agent);


### PR DESCRIPTION
## Changes

- use uuid v4 to generate unique ids for posts.