### PR TITLE
feat: use multipart/form-data for storj-interface uploads

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ serde_with = "3.12.0"
 
 # Common dependencies across workers
 cfg-if = "0.1.2"
-reqwest = { version = "0.12.15", features = ["json"] }
+reqwest = { version = "0.12.15", features = ["json", "multipart"] }
 stringreader = "0.1.1"
 uuid = { version = "1.17.0", features = ["v4", "serde", "js"] }
 k256 = { version = "0.13.4", default-features = false, features = ["std", "jwk"] }

--- a/workers/yral-upload-video/src/utils/storj_interface.rs
+++ b/workers/yral-upload-video/src/utils/storj_interface.rs
@@ -1,4 +1,4 @@
-use reqwest::Client;
+use reqwest::{multipart, Client};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::error::Error;
@@ -59,13 +59,12 @@ impl StorjInterface {
             self.base_url, publisher_user_id, video_id, is_nsfw
         );
 
-        let response = self
-            .client
-            .post(&url)
-            .header("Content-Type", "application/octet-stream")
-            .body(video_bytes)
-            .send()
-            .await?;
+        let part = multipart::Part::bytes(video_bytes)
+            .file_name("video.mp4")
+            .mime_str("video/mp4")?;
+        let form = multipart::Form::new().part("file", part);
+
+        let response = self.client.post(&url).multipart(form).send().await?;
 
         if !response.status().is_success() {
             let status = response.status();


### PR DESCRIPTION
Switch upload_pending from raw octet-stream to multipart/form-data, which is more reliable for large file uploads.